### PR TITLE
[fix] back button issue

### DIFF
--- a/lib/presentation/pages/connectivity_assistant.dart
+++ b/lib/presentation/pages/connectivity_assistant.dart
@@ -6,7 +6,8 @@ import '../../application/navigation/locations.dart';
 /// Connectivity assistant page
 class ConnectivityAssistantPage extends StatefulWidget {
   @override
-  _ConnectivityAssistantPageState createState() => _ConnectivityAssistantPageState();
+  _ConnectivityAssistantPageState createState() =>
+      _ConnectivityAssistantPageState();
 }
 
 class _ConnectivityAssistantPageState extends State<ConnectivityAssistantPage> {
@@ -22,13 +23,25 @@ class _ConnectivityAssistantPageState extends State<ConnectivityAssistantPage> {
             ElevatedButton(
               child: Text('Dashboard'),
               onPressed: () {
-                Beamer.of(context).beamTo(DashboardLocation());
+                Beamer.of(context).beamTo(DashboardLocation(
+                  BeamState(
+                    pathBlueprintSegments: [],
+                  ),
+                ));
+                // OR
+                // Beamer.of(context).beamToNamed('/');
               },
             ),
             ElevatedButton(
               child: Text('QR Code connect'),
               onPressed: () {
-                Beamer.of(context).beamTo(QrConnectLocation());
+                Beamer.of(context).beamTo(QrConnectLocation(
+                  BeamState(
+                    pathBlueprintSegments: ['qrconnect'],
+                  ),
+                ));
+                // OR
+                // Beamer.of(context).beamToNamed('/qrconnect');
               },
             ),
           ],

--- a/lib/presentation/pages/dashboard_page.dart
+++ b/lib/presentation/pages/dashboard_page.dart
@@ -22,13 +22,25 @@ class _DashboardPageState extends State<DashboardPage> {
             ElevatedButton(
               child: Text('QR Code connect'),
               onPressed: () {
-                Beamer.of(context).beamTo(QrConnectLocation());
+                Beamer.of(context).beamTo(QrConnectLocation(
+                  BeamState(
+                    pathBlueprintSegments: ['qrconnect'],
+                  ),
+                ));
+                // OR
+                // Beamer.of(context).beamToNamed('/qrconnect');
               },
             ),
             ElevatedButton(
               child: Text('Connectivity Assistant'),
               onPressed: () {
-                Beamer.of(context).beamTo(ConnectivityAssistantLocation());
+                Beamer.of(context).beamTo(ConnectivityAssistantLocation(
+                  BeamState(
+                    pathBlueprintSegments: ['connect'],
+                  ),
+                ));
+                // OR
+                // Beamer.of(context).beamToNamed('/connect');
               },
             )
           ],

--- a/lib/presentation/pages/qr_connect_page.dart
+++ b/lib/presentation/pages/qr_connect_page.dart
@@ -22,7 +22,13 @@ class _QrConnectPageState extends State<QrConnectPage> {
             ElevatedButton(
               child: Text('Dashboard'),
               onPressed: () {
-                Beamer.of(context).beamTo(DashboardLocation());
+                Beamer.of(context).beamTo(DashboardLocation(
+                  BeamState(
+                    pathBlueprintSegments: [],
+                  ),
+                ));
+                // OR
+                // Beamer.of(context).beamToNamed('/');
               },
             )
           ],


### PR DESCRIPTION
The problem was that you were always beaming to the same `BeamState` - the empty one. This is a common thing people do, especially when not trying the app on web. In browser it would be clearer that something isn't right because the URL would never change.

Back button dispatcher tried to `pop`, but you always had just one page in a stack. Then it tried to `beamBack` through `beamStateHistory`, but there was just one entry - the empty `BeamState` (duplicate `BeamState`s are not stored in history because they represent the same thing).

The solution is to manually specify different `BeamState` when beaming to a different page stack or simply use `beamToNamed` which will do that for you.

Let me know if this sounds alright to you or you have any further questions.